### PR TITLE
Add '-q' option in the usage output

### DIFF
--- a/src/mbpoll.c
+++ b/src/mbpoll.c
@@ -1259,6 +1259,7 @@ vUsage (FILE * stream, int exit_msg) {
            "  -1            Poll only once only, otherwise every poll rate interval\n"
            "  -l #          Poll rate in ms, ( > %d, %d is default)\n"
            "  -o #          Time-out in seconds (%.2f - %.2f, %.2f s is default)\n"
+           "  -q            Less verbose output\n"
            "Options for ModBus / TCP : \n"
            "  -p #          TCP port number (%s is default)\n"
            "Options for ModBus RTU : \n"


### PR DESCRIPTION
I missed to add the option in the usage text of my last commit. :-/