### PR TITLE
Ensure MIN, MAX macros are defined

### DIFF
--- a/src/mbpoll.c
+++ b/src/mbpoll.c
@@ -62,6 +62,13 @@
 #define PDEBUG(...)  if (ctx.bIsVerbose) printf(__VA_ARGS__)
 #endif
 
+#ifndef MIN
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+
+#ifndef MAX
+#define MAX(a,b) (((a)>(b))?(a):(b))
+#endif
 
 /* types ==================================================================== */
 typedef enum {


### PR DESCRIPTION
MIN/MAX macros not defined in some build environments
Implementing the logic in the calling functions might be preferable