### PR TITLE
Fix for using USB dongles with auto-switch

### DIFF
--- a/src/mbpoll.c
+++ b/src/mbpoll.c
@@ -826,7 +826,10 @@ main (int argc, char **argv) {
       modbus_free (ctx.xBus);
       vIoErrorExit ("Can't set RS485 mode (RTU): %s", modbus_strerror (errno));
     }
-    modbus_rtu_set_rts (ctx.xBus, ctx.iRtuMode);
+    if (modbus_rtu_set_rts (ctx.xBus, ctx.iRtuMode)) {
+      modbus_free (ctx.xBus);
+      vIoErrorExit ("Can't set RTS mode: %s", modbus_strerror (errno));
+    }
   }
 
   // Connection au bus


### PR DESCRIPTION
Hi,
I'm using a USB dongle based on a RS232 driver and the RTS line that drives the line.
The current implementation is selecting the RS485 mode when RTU is used. However this cause an error, since the USB driver is not implementing the `ioctl` to enable the RS485 behavior (the dongle is actually a RS232 driver).
The error is not checked by the code, so I was not able to figure out the error (I added a check).
So I believe that the correct logic would be:
- If no RTS setup is passed at the command line, the RTU must implement the RS485 logic.
- If RTS setup (pin, polarity, etc..) is passed at the command line, the RTU should be opened in RS232 mode instead.

If you think that instead a new explicit command-line switch should be used instead, please let me know. The current proposed implementation has the advantage of not requiring any other setup.

Thanks, Luciano
