### PR TITLE
enable libmodbus quirks

### DIFF
--- a/src/mbpoll.c
+++ b/src/mbpoll.c
@@ -821,6 +821,7 @@ main (int argc, char **argv) {
     vIoErrorExit ("Unable to create the libmodbus context");
   }
   modbus_set_debug (ctx.xBus, ctx.bIsVerbose);
+  modbus_enable_quirks(ctx.xBus, MODBUS_QUIRK_ALL);
 
   if (false == ctx.bIsQuiet) {
     vHello();


### PR DESCRIPTION
mbpoll, being a tool likely used for testing/debugging, should give it's users access to all possible options, without forcing them to recompile.